### PR TITLE
Improve navigation consistency and error handling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,16 @@
   publish = "dist"
 
 [[redirects]]
+  from = "/*/"
+  to = "/:splat"
+  status = 301
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[redirects]]
+  from = "/404"
+  to = "/404.html"
+  status = 404

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; URL=/404" />
+  <title>Page Not Found</title>
+</head>
+<body>
+  <p>404 | This page could not be found.</p>
+</body>
+</html>

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -35,6 +35,11 @@
     @apply hover:bg-black/5 dark:hover:bg-white/10;
 }
 
+.navbar-link {
+    @apply text-gray-700 dark:text-gray-300 font-medium transition-colors duration-200;
+    @apply hover:text-indigo-600 dark:hover:text-indigo-400;
+}
+
 /* --- Enhanced Glassmorphism Sidebar --- */
 .sidebar {
     @apply fixed inset-y-0 left-0 z-40 flex w-64 flex-col transition-transform duration-300 ease-in-out;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -39,6 +39,12 @@ const Navbar = ({ setSidebarOpen }) => {
                 </Link>
             </div>
 
+            <nav className="hidden lg:flex items-center gap-6">
+                <Link to="/boards" className="navbar-link">বোর্ড প্রশ্ন</Link>
+                <Link to="/chapter-wise" className="navbar-link">অধ্যায়ভিত্তিক অনুশীলন</Link>
+                <Link to="/mock-test" className="navbar-link">মক টেস্ট</Link>
+            </nav>
+
             <div className="flex items-center gap-3">
                 {/* Theme toggle */}
                 <button

--- a/src/features/board/index.jsx
+++ b/src/features/board/index.jsx
@@ -207,6 +207,7 @@ const BoardQuestions = () => {
                 <Motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }} className="hero-section">
                     <h1 className="hero-title">বিষয় বাছাই করুন</h1>
                     <p className="hero-subtitle">অনুশীলন অথবা পরীক্ষার জন্য একটি বিষয় বাছাই করুন।</p>
+                    <h2 className="sr-only">বিষয় তালিকা</h2>
                 </Motion.div>
                 
                 <Motion.div 

--- a/src/features/chapter/index.jsx
+++ b/src/features/chapter/index.jsx
@@ -73,6 +73,7 @@ const SubjectSelection = () => {
       <header className="cw-hero">
         <h1 className="cw-hero-title">অধ্যায়ভিত্তিক অনুশীলন</h1>
         <p className="cw-hero-subtitle">বিষয় বেছে নিন → অধ্যায় নির্বাচন করুন → অনুশীলন শুরু করুন।</p>
+        <h2 className="sr-only">বিষয় তালিকা</h2>
       </header>
       <Motion.div className="subject-grid" variants={listContainerVariants} initial="hidden" animate="visible">
         {Object.entries(subjectConfig).map(([key, { icon, displayName }]) => (


### PR DESCRIPTION
## Summary
- add redirects to normalize URLs and expose 404 page
- link boards, chapter-wise and mock-test from top navigation
- ensure each main listing view contains an h2 heading

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc482a4c832cb86d71715cad602a